### PR TITLE
fix: enable access to outer wilds game folder on steam flatpak

### DIFF
--- a/com.outerwildsmods.owmods_gui.yml
+++ b/com.outerwildsmods.owmods_gui.yml
@@ -15,6 +15,7 @@ finish-args:
   - --filesystem=~/Games/Heroic/OuterWilds
   - --filesystem=~/.local/share/OuterWildsModManager
   - --filesystem=~/.var/app/com.valvesoftware.Steam/.local/share/OuterWildsModManager
+  - --filesystem=~/.var/app/com.valvesoftware.Steam/.local/share/Steam/steamapps/common/Outer Wilds/
   - --filesystem=/tmp
   - --device=dri
   - --env=WEBKIT_DISABLE_COMPOSITING_MODE=1


### PR DESCRIPTION
This commit allows outer wilds mod manager to install outer wilds game-specific mods to the steam flatpak's outer wilds game folder.